### PR TITLE
检查文档错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GoDoc](https://godoc.org/github.com/modelpack/model-spec?status.svg)](https://godoc.org/github.com/modelpack/model-spec)
 [![Discussions](https://img.shields.io/badge/discussions-on%20github-blue?style=flat-square)](https://github.com/modelpack/model-spec/discussions)
 
-The Cloud Native Computing Foundation's (CNCF) ModelPack project is a vendor-neutral, open source specification standard to package, distribute and run AI models in a cloud native environments. It's goal is to enable the creation of standard-compliant implementations that would move AI/ML project artifacts out of vendor-controlled, proprietary formats and into a standardized and interchangeable format that is compatible with the cloud-native ecosystem.
+The Cloud Native Computing Foundation's (CNCF) ModelPack project is a vendor-neutral, open source specification standard to package, distribute and run AI models in a cloud native environments. Its goal is to enable the creation of standard-compliant implementations that would move AI/ML project artifacts out of vendor-controlled, proprietary formats and into a standardized and interchangeable format that is compatible with the cloud-native ecosystem.
 
 ## Rationale
 

--- a/文档错误检查报告.md
+++ b/文档错误检查报告.md
@@ -1,0 +1,113 @@
+# 文档错误检查报告
+
+## 检查概述
+
+本报告对 CNCF ModelPack 规范项目的文档进行了全面检查，涵盖了以下文档：
+
+- `README.md`
+- `CONTRIBUTING.md` 
+- `GOVERNANCE.md`
+- `MAINTAINERS.md`
+- `code-of-conduct.md`
+- `ROADMAP.md`
+- `docs/spec.md`
+- `docs/config.md`
+- `docs/annotations.md`
+
+## 发现的错误
+
+### 1. 语法错误
+
+**文件**: `README.md`  
+**位置**: 第5行  
+**问题**: `It's goal` 应该是 `Its goal`  
+**说明**: 这里应该使用所有格代词 "its"，而不是缩写 "it's"（it is 的缩写）。
+
+**当前内容**:
+```
+The Cloud Native Computing Foundation's (CNCF) ModelPack project is a vendor-neutral, open source specification standard to package, distribute and run AI models in a cloud native environments. It's goal is to enable...
+```
+
+**建议修正**:
+```
+The Cloud Native Computing Foundation's (CNCF) ModelPack project is a vendor-neutral, open source specification standard to package, distribute and run AI models in a cloud native environments. Its goal is to enable...
+```
+
+### 2. 内部链接检查
+
+**文件**: `GOVERNANCE.md`  
+**位置**: 第12行  
+**问题**: 链接引用 `#code-of-conduct` 但实际标题是 "Code of Conduct"  
+**说明**: 目标锚点存在，链接有效。
+
+**文件**: `GOVERNANCE.md`  
+**位置**: 第13行  
+**检查结果**: 链接引用 `#modifying-this-charter` 指向 "Modifying this Charter" 标题  
+**说明**: ✅ 目标锚点存在，链接有效。
+
+### 3. 文件引用检查
+
+✅ **图片文件引用正常**:
+- `docs/img/infra-trends.png` - 存在
+- `docs/img/build-and-push.png` - 存在  
+- `docs/img/pull-and-serve.png` - 存在
+- `docs/img/manifest.svg` - 存在
+
+✅ **内部文档链接正常**:
+- 所有 `docs/` 目录下的相互引用都正确
+- LICENSE 文件存在
+- MAINTAINERS.md 文件存在
+
+### 4. 外部链接（需要进一步验证）
+
+以下外部链接在文档中出现，建议定期检查其有效性：
+
+**GitHub 链接**:
+- `https://github.com/modelpack/model-spec`
+- `https://github.com/opencontainers/image-spec/`
+- 其他 OCI 相关链接
+
+**工具和资源链接**:
+- `https://godoc.org/github.com/modelpack/model-spec`
+- `https://go.dev/`
+- `https://golangci-lint.run/`
+- Slack 工作区链接
+
+## 格式和一致性检查
+
+### ✅ 正常的格式特征
+
+1. **Markdown 语法**: 所有文档使用标准 Markdown 格式
+2. **标题层级**: 标题层级结构合理
+3. **代码块**: 代码示例格式正确
+4. **列表格式**: 有序和无序列表格式一致
+
+### 📝 注意事项
+
+1. **Maintainer 列表**: MAINTAINERS.md 中的维护者列表格式简洁，仅包含用户名
+2. **许可证引用**: 所有许可证引用都指向正确的 LICENSE 文件
+
+## 配置文件检查
+
+### ✅ 检查的配置文件
+
+1. **`.markdownlint.yml`**: 配置合理，禁用了一些不必要的规则
+2. **`.typos.toml`**: 拼写检查配置完整，排除了适当的文件类型
+3. **`.gitignore`**: 包含适当的忽略规则
+
+## 建议修复
+
+### 高优先级
+1. **立即修复**: README.md 中的语法错误 (`It's` → `Its`)
+
+### 中优先级  
+1. **验证链接**: 定期检查外部链接的有效性
+2. **锚点检查**: 验证 GOVERNANCE.md 中的所有内部链接锚点
+
+### 低优先级
+1. **工具集成**: 考虑在CI中集成自动化的文档检查工具
+2. **一致性**: 保持所有文档的写作风格一致
+
+## 总结
+
+总体而言，项目文档质量较高，结构清晰，只发现了一个明确的语法错误需要修复。大部分内容符合技术文档的标准，链接结构合理，格式一致。建议优先修复发现的语法错误，并建立定期的文档检查流程。


### PR DESCRIPTION
## Fix: Corrected typo in README and generated documentation error report

## Description

-   Corrected a grammatical error in `README.md` (changed "It's goal" to "Its goal").
-   Generated a comprehensive documentation error report (`文档错误检查报告.md`) detailing findings, suggested fixes, and overall quality assessment.

## Related Issue

N/A

## Motivation and Context

This change addresses a user request to check for documentation errors. It improves the accuracy of the `README.md` and provides a detailed report to help maintain overall documentation quality.